### PR TITLE
Add simple Flutter game view

### DIFF
--- a/frontend/lib/views/game/game_view.dart
+++ b/frontend/lib/views/game/game_view.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+class GameView extends StatefulWidget {
+  const GameView({Key? key}) : super(key: key);
+
+  @override
+  _GameViewState createState() => _GameViewState();
+}
+
+class _GameViewState extends State<GameView> {
+  List<int> _board = List.filled(9, 0); // 0 empty, 1 X, 2 O
+  int _currentPlayer = 1;
+  bool _gameOver = false;
+  String _message = "Player X's turn";
+
+  void _handleTap(int index) {
+    if (_board[index] == 0 && !_gameOver) {
+      setState(() {
+        _board[index] = _currentPlayer;
+        if (_checkWinner(_currentPlayer)) {
+          _gameOver = true;
+          _message = 'Player ${_currentPlayer == 1 ? 'X' : 'O'} wins!';
+        } else if (!_board.contains(0)) {
+          _gameOver = true;
+          _message = "It's a draw!";
+        } else {
+          _currentPlayer = _currentPlayer == 1 ? 2 : 1;
+          _message = "Player ${_currentPlayer == 1 ? 'X' : 'O'}'s turn";
+        }
+      });
+    }
+  }
+
+  bool _checkWinner(int player) {
+    const wins = [
+      [0, 1, 2],
+      [3, 4, 5],
+      [6, 7, 8],
+      [0, 3, 6],
+      [1, 4, 7],
+      [2, 5, 8],
+      [0, 4, 8],
+      [2, 4, 6]
+    ];
+    for (var win in wins) {
+      if (_board[win[0]] == player &&
+          _board[win[1]] == player &&
+          _board[win[2]] == player) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void _resetGame() {
+    setState(() {
+      _board = List.filled(9, 0);
+      _currentPlayer = 1;
+      _gameOver = false;
+      _message = "Player X's turn";
+    });
+  }
+
+  Widget _buildCell(int index) {
+    return GestureDetector(
+      onTap: () => _handleTap(index),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: Colors.blueAccent, width: 2),
+        ),
+        child: Center(
+          child: Text(
+            _board[index] == 1
+                ? 'X'
+                : _board[index] == 2
+                    ? 'O'
+                    : '',
+            style: const TextStyle(
+              fontSize: 48,
+              fontWeight: FontWeight.bold,
+              color: Colors.black87,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(title: const Text('Tic Tac Toe')),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          AspectRatio(
+            aspectRatio: 1,
+            child: GridView.builder(
+              padding: const EdgeInsets.all(20),
+              itemCount: 9,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+              ),
+              itemBuilder: (context, index) => _buildCell(index),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            _message,
+            style: const TextStyle(fontSize: 24),
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(
+            onPressed: _resetGame,
+            child: const Text('Restart'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/views/main_layout.dart
+++ b/frontend/lib/views/main_layout.dart
@@ -8,6 +8,7 @@ import 'package:auto_gpt_flutter_client/views/skill_tree/skill_tree_view.dart';
 import 'package:auto_gpt_flutter_client/views/task/task_view.dart';
 import 'package:auto_gpt_flutter_client/views/chat/chat_view.dart';
 import 'package:auto_gpt_flutter_client/views/task_queue/task_queue_view.dart';
+import 'package:auto_gpt_flutter_client/views/game/game_view.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 
@@ -38,9 +39,10 @@ class MainLayout extends StatelessWidget {
     // Calculate remaining width after subtracting the width of the SideBarView
     double remainingWidth = width - sideBarWidth;
 
-    // Declare variables to hold the widths of SkillTreeView, TestQueueView, and ChatView
+    // Declare variables to hold the widths of SkillTreeView, TestQueueView, GameView, and ChatView
     double skillTreeViewWidth = 0;
     double testQueueViewWidth = 0;
+    double gameViewWidth = 0;
     double chatViewWidth = 0;
 
     if (width > 800) {
@@ -84,6 +86,11 @@ class MainLayout extends StatelessWidget {
                             child: ChatView(viewModel: chatViewModel)),
                       ],
                     );
+                  } else if (value == 'GameView') {
+                    skillTreeViewModel.resetState();
+                    gameViewWidth = remainingWidth;
+                    return SizedBox(
+                        width: gameViewWidth, child: const GameView());
                   } else {
                     if (skillTreeViewModel.selectedNode != null) {
                       // If TaskQueueView should be displayed
@@ -132,6 +139,10 @@ class MainLayout extends StatelessWidget {
               icon: Icon(CupertinoIcons.chat_bubble),
               label: 'Chat',
             ),
+            BottomNavigationBarItem(
+              icon: Icon(CupertinoIcons.game_controller),
+              label: 'Game',
+            ),
           ],
         ),
         tabBuilder: (BuildContext context, int index) {
@@ -149,6 +160,13 @@ class MainLayout extends StatelessWidget {
               returnValue = CupertinoTabView(builder: (context) {
                 return CupertinoPageScaffold(
                   child: SafeArea(child: ChatView(viewModel: chatViewModel)),
+                );
+              });
+              break;
+            case 2:
+              returnValue = CupertinoTabView(builder: (context) {
+                return const CupertinoPageScaffold(
+                  child: SafeArea(child: GameView()),
                 );
               });
               break;

--- a/frontend/lib/views/side_bar/side_bar_view.dart
+++ b/frontend/lib/views/side_bar/side_bar_view.dart
@@ -44,6 +44,15 @@ class SideBarView extends StatelessWidget {
                             ? null
                             : () => selectedViewNotifier.value = 'TaskView',
                       ),
+                      IconButton(
+                        splashRadius: 0.1,
+                        color: selectedView == 'GameView'
+                            ? Colors.blue
+                            : Colors.black,
+                        icon: const Icon(Icons.sports_esports),
+                        onPressed: () =>
+                            selectedViewNotifier.value = 'GameView',
+                      ),
                       if (Provider.of<SettingsViewModel>(context, listen: true)
                           .isDeveloperModeEnabled)
                         IconButton(


### PR DESCRIPTION
## Summary
- implement a small Tic‑Tac‑Toe game in Flutter
- integrate `GameView` into the sidebar and layout navigation
- extend small‑screen tab bar with a game tab

## Testing
- `flake8 .` *(fails: command not found)*
- `python -m flake8 .` *(fails: No module named 'flake8')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*